### PR TITLE
fix: Correct path in AutodartsTouch.sh

### DIFF
--- a/AutodartsTouch/AutodartsTouch.sh
+++ b/AutodartsTouch/AutodartsTouch.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 export DISPLAY=:0
 export XAUTHORITY="$HOME/.Xauthority"
 
-cd "$HOME/kiosk-electron" || exit 1
+cd "$HOME/AutodartsTouch" || exit 1
 
 # Start keyboard server in background (optional, keyboard page already loads via file://)
 node keyboard-server.js &>/dev/null &


### PR DESCRIPTION
The start script was still referencing the old `kiosk-electron` directory, causing a "Cannot find module" error upon launch.

This change updates the `cd` command in `AutodartsTouch.sh` to point to the correct `$HOME/AutodartsTouch` directory, resolving the startup failure.