### PR TITLE
feat: Implement configurable tabs in the toolbar

### DIFF
--- a/AutodartsTouch/index.html
+++ b/AutodartsTouch/index.html
@@ -35,8 +35,7 @@ button[aria-selected="true"]::after{content:"";display:block;margin:2px auto 0 a
     </div>
 
     <div id="tabs" role="tablist" aria-label="Seiten">
-      <button onclick="switchTab('tab1')" role="tab" aria-selected="true" id="tab1btn">Seite 1</button>
-      <button onclick="switchTab('tab2')" role="tab" aria-selected="false" id="tab2btn">Seite 2</button>
+      <!-- Tabs will be dynamically inserted here -->
     </div>
 
     <div style="display:flex;align-items:center;justify-content:center;">
@@ -46,13 +45,50 @@ button[aria-selected="true"]::after{content:"";display:block;margin:2px auto 0 a
   </div>
 
 <script>
-  const tabs = [document.getElementById('tab1btn'), document.getElementById('tab2btn')];
-  function setActive(id){ tabs.forEach(t => t.setAttribute('aria-selected', t.id === id+'btn' ? 'true' : 'false')); }
-  setActive('tab1');
-  function switchTab(id){ setActive(id); if(window.api && window.api.switchTab) window.api.switchTab(id); }
+  let tabButtons = [];
+
+  function setActive(id) {
+    tabButtons.forEach(t => {
+      t.setAttribute('aria-selected', t.id === id ? 'true' : 'false');
+    });
+  }
+
+  function switchTab(tabId) {
+    setActive(tabId);
+    if (window.api && window.api.switchTab) {
+      window.api.switchTab(tabId);
+    }
+  }
+
+  async function generateTabs() {
+    const tabsContainer = document.getElementById('tabs');
+    if (window.api && window.api.getTabs) {
+      const tabs = await window.api.getTabs();
+      tabs.forEach((tab, index) => {
+        if (tab.url) { // Only show tabs that have a URL
+          const button = document.createElement('button');
+          const tabId = `tab${index}`;
+          button.id = tabId;
+          button.textContent = tab.name || `Tab ${index + 1}`;
+          button.setAttribute('role', 'tab');
+          button.setAttribute('aria-selected', 'false');
+          button.onclick = () => switchTab(tabId);
+          tabsContainer.appendChild(button);
+          tabButtons.push(button);
+        }
+      });
+
+      // Set the first tab as active by default
+      if (tabButtons.length > 0) {
+        setActive(tabButtons[0].id);
+      }
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', generateTabs);
 
   const webVKBtn = document.getElementById('webVKBtn');
-  webVKBtn.addEventListener('pointerdown', (e) => { e.preventDefault(); if(window.api && window.api.toggleWebKeyboard) window.api.toggleWebKeyboard(); });
+  webVKBtn.addEventListener('pointerdown', (e) => { e.preventDefault(); if (window.api && window.api.toggleWebKeyboard) window.api.toggleWebKeyboard(); });
   webVKBtn.addEventListener('click', (e) => e.preventDefault());
 
   const settingsBtn = document.getElementById('settingsBtn');

--- a/AutodartsTouch/preload.js
+++ b/AutodartsTouch/preload.js
@@ -11,6 +11,7 @@ contextBridge.exposeInMainWorld('api', {
   switchTab: (t) => ipcRenderer.send('switch-tab', t),
   refresh: () => ipcRenderer.send('refresh'),
   toggleWebKeyboard: () => ipcRenderer.send('toggle-webkeyboard'),
+  getTabs: () => ipcRenderer.invoke('get-tabs'),
   sendKey: (key) => ipcRenderer.send('webkeyboard-key', key),
   setShiftStatus: (isActive) => ipcRenderer.send('keyboard-shift-status', isActive),
   reportKeyboardHeight: (height) => ipcRenderer.send('keyboard-height-changed', height),

--- a/AutodartsTouch/settings.html
+++ b/AutodartsTouch/settings.html
@@ -63,6 +63,70 @@
     <input type="range" id="keyHeight" min="30" max="80" value="50">
   </div>
 
+  <div class="tabs-settings">
+    <h2>Tab-Einstellungen</h2>
+    <!-- Tab 1 -->
+    <div class="tab-setting">
+      <h3 style="color: #fff; text-align: center;">Tab 1</h3>
+      <div class="setting">
+        <label for="tabName1">Tab-Name</label>
+        <input type="text" id="tabName1" placeholder="z.B. Autodarts">
+      </div>
+      <div class="setting">
+        <label for="tabUrl1">URL</label>
+        <input type="text" id="tabUrl1" placeholder="https://autodarts.io">
+      </div>
+    </div>
+    <!-- Tab 2 -->
+    <div class="tab-setting">
+      <h3 style="color: #fff; text-align: center;">Tab 2</h3>
+      <div class="setting">
+        <label for="tabName2">Tab-Name</label>
+        <input type="text" id="tabName2" placeholder="z.B. Google">
+      </div>
+      <div class="setting">
+        <label for="tabUrl2">URL</label>
+        <input type="text" id="tabUrl2" placeholder="https://google.com">
+      </div>
+    </div>
+    <!-- Tab 3 -->
+    <div class="tab-setting">
+      <h3 style="color: #fff; text-align: center;">Tab 3</h3>
+      <div class="setting">
+        <label for="tabName3">Tab-Name</label>
+        <input type="text" id="tabName3" placeholder="Name für Tab 3">
+      </div>
+      <div class="setting">
+        <label for="tabUrl3">URL</label>
+        <input type="text" id="tabUrl3" placeholder="URL für Tab 3">
+      </div>
+    </div>
+    <!-- Tab 4 -->
+    <div class="tab-setting">
+      <h3 style="color: #fff; text-align: center;">Tab 4</h3>
+      <div class="setting">
+        <label for="tabName4">Tab-Name</label>
+        <input type="text" id="tabName4" placeholder="Name für Tab 4">
+      </div>
+      <div class="setting">
+        <label for="tabUrl4">URL</label>
+        <input type="text" id="tabUrl4" placeholder="URL für Tab 4">
+      </div>
+    </div>
+    <!-- Tab 5 -->
+    <div class="tab-setting">
+      <h3 style="color: #fff; text-align: center;">Tab 5</h3>
+      <div class="setting">
+        <label for="tabName5">Tab-Name</label>
+        <input type="text" id="tabName5" placeholder="Name für Tab 5">
+      </div>
+      <div class="setting">
+        <label for="tabUrl5">URL</label>
+        <input type="text" id="tabUrl5" placeholder="URL für Tab 5">
+      </div>
+    </div>
+  </div>
+
   <div class="buttons">
     <button id="saveBtn">Speichern & Schließen</button>
     <button id="closeBtn">Schließen</button>
@@ -74,6 +138,22 @@
     const keyHeightSlider = document.getElementById('keyHeight');
     const saveBtn = document.getElementById('saveBtn');
     const closeBtn = document.getElementById('closeBtn');
+
+    const tabNameInputs = [
+      document.getElementById('tabName1'),
+      document.getElementById('tabName2'),
+      document.getElementById('tabName3'),
+      document.getElementById('tabName4'),
+      document.getElementById('tabName5'),
+    ];
+
+    const tabUrlInputs = [
+      document.getElementById('tabUrl1'),
+      document.getElementById('tabUrl2'),
+      document.getElementById('tabUrl3'),
+      document.getElementById('tabUrl4'),
+      document.getElementById('tabUrl5'),
+    ];
 
     function sendLiveUpdate() {
       if (window.electronAPI && window.electronAPI.updateKeyboardStyleLive) {
@@ -92,6 +172,12 @@
           if (settings.volume) volumeSlider.value = settings.volume;
           if (settings.keyboardWidth) keyboardWidthSlider.value = settings.keyboardWidth;
           if (settings.keyHeight) keyHeightSlider.value = settings.keyHeight;
+          if (settings.tabs) {
+            settings.tabs.forEach((tab, index) => {
+              if (tabNameInputs[index]) tabNameInputs[index].value = tab.name;
+              if (tabUrlInputs[index]) tabUrlInputs[index].value = tab.url;
+            });
+          }
         }
       });
     }
@@ -101,11 +187,24 @@
     keyHeightSlider.addEventListener('input', sendLiveUpdate);
 
     saveBtn.addEventListener('click', () => {
+      const tabs = [];
+      for (let i = 0; i < 5; i++) {
+        const name = tabNameInputs[i].value.trim();
+        const url = tabUrlInputs[i].value.trim();
+        if (name && url) {
+          tabs.push({ name, url });
+        } else {
+          tabs.push({ name: '', url: '' });
+        }
+      }
+
       const settings = {
         volume: volumeSlider.value,
         keyboardWidth: keyboardWidthSlider.value,
-        keyHeight: keyHeightSlider.value
+        keyHeight: keyHeightSlider.value,
+        tabs: tabs,
       };
+
       if (window.electronAPI && window.electronAPI.saveSettings) {
         window.electronAPI.saveSettings(settings);
       }


### PR DESCRIPTION
This commit introduces a dynamic tab system, allowing users to configure up to five tabs in the application's toolbar.

- **Settings (`settings.html`)**: Added input fields for tab names and URLs. The UI now loads and saves these settings.
- **Main Process (`main.js`)**: Updated to dynamically create `BrowserView` instances for each configured tab. It now saves and retrieves tab settings from `electron-store`. A dialog was added to inform users that a restart is needed for tab changes to take effect.
- **Preload Script (`preload.js`)**: Exposed a new `get-tabs` function to securely provide tab configurations to the toolbar.
- **Toolbar (`index.html`)**: Replaced hardcoded tab buttons with a script that dynamically generates them based on the user's settings. Only tabs with a defined URL are displayed.